### PR TITLE
Manifest v3 chrome fix

### DIFF
--- a/background.js
+++ b/background.js
@@ -229,6 +229,14 @@ var checkForGitDir = function(data, url){
     }
 
 }
+
+var fetchText = function(url, callback){
+    fetch(url, {"credentials": 'include'})
+        .then(response => response.text())
+        .then(callback)
+        .catch(error => console.debug("Trufflehog skipped fetch", url, error));
+}
+
 var js_url;
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
@@ -262,9 +270,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
                             let parentOrigin = request.parentOrigin;
                             checkIfOriginDenied(js_url, function(skip){
                                 if (!skip){
-                                    fetch(js_url, {"credentials": 'include'})
-                                        .then(response => response.text())
-                                        .then(data => checkData(data, js_url, regexes, undefined, parentUrl, parentOrigin));
+                                    fetchText(js_url, data => checkData(data, js_url, regexes, undefined, parentUrl, parentOrigin));
                                 }
 
                             })
@@ -277,9 +283,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
                             })
                         }else if(request.envFile){
                             if(checkEnv['checkEnv']){
-                                fetch(request.envFile, {"credentials": 'include'})
-                                    .then(response => response.text())
-                                    .then(data => checkData(data, ".env file at " + request.envFile, regexes, undefined, request.parentUrl, request.parentOrigin));
+                                fetchText(request.envFile, data => checkData(data, ".env file at " + request.envFile, regexes, undefined, request.parentUrl, request.parentOrigin));
                             }
                         }else if(request.openTabs){
                             for (tab of request.openTabs){
@@ -288,9 +292,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
                             }
                         }else if(request.gitDir){
                             if(checkGit['checkGit']){
-                            fetch(request.gitDir, {"credentials": 'include'})
-                                    .then(response => response.text())
-                                    .then(data => checkForGitDir(data, request.gitDir));
+                            fetchText(request.gitDir, data => checkForGitDir(data, request.gitDir));
                             }
 
                         }
@@ -305,4 +307,3 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
     return true;
 });
-

--- a/background.js
+++ b/background.js
@@ -233,8 +233,7 @@ var checkForGitDir = function(data, url){
 var fetchText = function(url, callback){
     fetch(url, {"credentials": 'include'})
         .then(response => response.text())
-        .then(callback)
-        .catch(error => console.debug("Trufflehog skipped fetch", url, error));
+        .then(callback, error => console.debug("Trufflehog skipped fetch", url, error));
 }
 
 var js_url;

--- a/background.js
+++ b/background.js
@@ -1,31 +1,14 @@
 // this is the background code...
 
-// listen for our browerAction to be clicked
-// for the current tab, inject the "inject.js" file & execute it
-
-
-var currentTab;
 var version = "1.0";
 
-chrome.tabs.query( //get current Tab
-    {
-        currentWindow: true,
-        active: true
-    },
-    function(tabArray) {
-        currentTab = tabArray[0];
-        chrome.tabs.executeScript(currentTab.ib, {
-            file: 'inject.js'
-        });
-    }
-)
-
-chrome.storage.sync.get(['ranOnce'], function(ranOnce) {
-    if (! ranOnce.ranOnce){
-        chrome.storage.sync.set({"ranOnce": true});
-        chrome.storage.sync.set({"originDenyList": ["https://www.google.com"]});
-    }
-
+chrome.runtime.onInstalled.addListener(function() {
+    chrome.storage.sync.get(['ranOnce'], function(ranOnce) {
+        if (! ranOnce.ranOnce){
+            chrome.storage.sync.set({"ranOnce": true});
+            chrome.storage.sync.set({"originDenyList": ["https://www.google.com"]});
+        }
+    })
 })
 
 
@@ -149,29 +132,38 @@ var updateTabAndAlert = function(finding){
     chrome.storage.sync.get(["alerts"], function(result) {
         console.log(result.alerts)
         if (result.alerts == undefined || result.alerts){
-            if (fromEncoded){
-                alert(key + ": " + match + " found in " + src + " decoded from " + fromEncoded.substring(0,9) + "...");
-            }else{
-                alert(key + ": " + match + " found in " + src);
-            }
+            var message = fromEncoded
+                ? key + ": " + match + " found in " + src + " decoded from " + fromEncoded.substring(0,9) + "..."
+                : key + ": " + match + " found in " + src;
+            chrome.notifications.create({
+                type: "basic",
+                iconUrl: "icon128.png",
+                title: "Trufflehog",
+                message: message.substring(0, 400)
+            });
         }
     })
     updateTab();
 }
 
 var updateTab = function(){
-     chrome.tabs.getSelected(null, function(tab) {
-        var tabId = tab.id;
+    chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+        var tab = tabs && tabs[0];
+        if (!tab || !tab.url || !tab.url.startsWith("http")){
+            chrome.action.setBadgeText({text: ""});
+            return;
+        }
         var tabUrl = tab.url;
         var origin = (new URL(tabUrl)).origin
         chrome.storage.sync.get(["leakedKeys"], function(result) {
-            if (Array.isArray(result.leakedKeys[origin])){
-                var originKeys = result.leakedKeys[origin].length.toString();
+            var leakedKeys = result.leakedKeys || {};
+            if (Array.isArray(leakedKeys[origin])){
+                var originKeys = leakedKeys[origin].length.toString();
             }else{
                 var originKeys = "";
             }
-            chrome.browserAction.setBadgeText({text: originKeys});
-            chrome.browserAction.setBadgeBackgroundColor({color: '#ff0000'});
+            chrome.action.setBadgeText({text: originKeys});
+            chrome.action.setBadgeBackgroundColor({color: '#ff0000'});
         })
     });
 }
@@ -222,7 +214,7 @@ var getDecodedb64 = function(inputString){
 var checkIfOriginDenied = function(check_url, cb){
     let skip = false;
     chrome.storage.sync.get(["originDenyList"], function(result) {
-        let originDenyList = result.originDenyList;
+        let originDenyList = result.originDenyList || [];
         for (origin of originDenyList){
             if(check_url.startsWith(origin)){
                 skip = true;
@@ -233,12 +225,12 @@ var checkIfOriginDenied = function(check_url, cb){
 }
 var checkForGitDir = function(data, url){
     if(data.startsWith("[core]")){
-        alert(".git dir found in " + url + " feature to check this for secrets not supported");
+        chrome.notifications.create({type: "basic", iconUrl: "icon128.png", title: "Trufflehog", message: ".git dir found in " + url + " feature to check this for secrets not supported"});
     }
 
 }
 var js_url;
-chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
     chrome.storage.sync.get(['generics'], function(useGenerics) {
         chrome.storage.sync.get(['specifics'], function(useSpecifics) {
@@ -291,7 +283,7 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
                             }
                         }else if(request.openTabs){
                             for (tab of request.openTabs){
-                                window.open(tab);
+                                chrome.tabs.create({url: tab});
                                 console.log(tab)
                             }
                         }else if(request.gitDir){
@@ -311,5 +303,6 @@ chrome.extension.onMessage.addListener(function(request, sender, sendResponse) {
 
 
 
+    return true;
 });
 

--- a/background.js
+++ b/background.js
@@ -305,5 +305,4 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
 
 
-    return true;
 });

--- a/background.js
+++ b/background.js
@@ -89,7 +89,7 @@ var checkData = function(data, src, regexes, fromEncoded=false, parentUrl=undefi
         }
     }
     if (findings){
-        chrome.storage.sync.get(["leakedKeys"], function(result) {
+        chrome.storage.local.get(["leakedKeys"], function(result) {
             if (Array.isArray(result.leakedKeys) || ! result.leakedKeys){
                 var keys = {};
             }else{
@@ -106,13 +106,13 @@ var checkData = function(data, src, regexes, fromEncoded=false, parentUrl=undefi
                     }
                     if(newFinding){
                         keys[parentOrigin].push(finding)
-                        chrome.storage.sync.set({"leakedKeys": keys}, function(){
+                        chrome.storage.local.set({"leakedKeys": keys}, function(){
                             updateTabAndAlert(finding);
                         });
                     }
                 }else{
                     keys[parentOrigin] = [finding];
-                    chrome.storage.sync.set({"leakedKeys": keys}, function(){
+                    chrome.storage.local.set({"leakedKeys": keys}, function(){
                         updateTabAndAlert(finding);
                     })
                 }
@@ -155,7 +155,7 @@ var updateTab = function(){
         }
         var tabUrl = tab.url;
         var origin = (new URL(tabUrl)).origin
-        chrome.storage.sync.get(["leakedKeys"], function(result) {
+        chrome.storage.local.get(["leakedKeys"], function(result) {
             var leakedKeys = result.leakedKeys || {};
             if (Array.isArray(leakedKeys[origin])){
                 var originKeys = leakedKeys[origin].length.toString();

--- a/manifest.json
+++ b/manifest.json
@@ -1,25 +1,25 @@
 {
   "name": "Trufflehog",
   "version": "0.0.1",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "Sniffing out credentials",
   "homepage_url": "https://trufflesecurity.com",
   "background": {
-    "scripts": [
-      "background.js"
-    ],
-    "persistent": true
+    "service_worker": "background.js"
   },
-  "browser_action": {
+  "action": {
     "default_title": "Trufflehog",
     "default_popup": "popup.html"
   },
   "permissions": [
-    "https://*/*",
-    "http://*/*",
     "activeTab",
     "tabs",
-    "storage"
+    "storage",
+    "notifications"
+  ],
+  "host_permissions": [
+    "https://*/*",
+    "http://*/*"
   ],
   "icons": { "16": "icon16.png",
            "48": "icon48.png",

--- a/popup.js
+++ b/popup.js
@@ -112,7 +112,7 @@ document.getElementById("clearOriginFindings").addEventListener("click", functio
             var tab = tabs[0];
             var origin = (new URL(tab.url)).origin;
             var leakedKeys = result.leakedKeys || {};
-            leakedKeys[origin] = [];
+            leakedKeys[origin] = {};
             chrome.storage.sync.set({"leakedKeys": leakedKeys});
             chrome.action.setBadgeText({text: ''});
             document.getElementById("findingList").innerHTML = "";

--- a/popup.js
+++ b/popup.js
@@ -64,7 +64,7 @@ for (i = 0; i < acc.length; i++) {
         var tab = tabs[0];
 
         var origin = (new URL(tab.url)).origin;
-        chrome.storage.sync.get(["leakedKeys"], function(result) {
+        chrome.storage.local.get(["leakedKeys"], function(result) {
             var leakedKeys = result.leakedKeys || {};
             var keys = leakedKeys[origin];
             let keyInfo = "";
@@ -87,7 +87,7 @@ for (i = 0; i < acc.length; i++) {
 }
 
 var downloadCSV = function(){
-    chrome.storage.sync.get(["leakedKeys"], function(result) {
+    chrome.storage.local.get(["leakedKeys"], function(result) {
         let csvRows = [];
         var leakedKeys = result.leakedKeys || {};
         for (let origin in leakedKeys){
@@ -107,25 +107,25 @@ document.getElementById("downloadAllFindings").addEventListener("click", functio
     downloadCSV();
 })
 document.getElementById("clearOriginFindings").addEventListener("click", function() {
-    chrome.storage.sync.get(["leakedKeys"], function(result) {
+    chrome.storage.local.get(["leakedKeys"], function(result) {
         chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
             var tab = tabs[0];
             var origin = (new URL(tab.url)).origin;
             var leakedKeys = result.leakedKeys || {};
             leakedKeys[origin] = {};
-            chrome.storage.sync.set({"leakedKeys": leakedKeys});
+            chrome.storage.local.set({"leakedKeys": leakedKeys});
             chrome.action.setBadgeText({text: ''});
             document.getElementById("findingList").innerHTML = "";
         })
     })
 })
 document.getElementById("clearAllFindings").addEventListener("click", function() {
-    chrome.storage.sync.get(["leakedKeys"], function(result) {
+    chrome.storage.local.get(["leakedKeys"], function(result) {
         chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
             var tab = tabs[0];
             var origin = (new URL(tab.url)).origin;
             result.leakedKeys = {};
-            chrome.storage.sync.set({"leakedKeys": result.leakedKeys});
+            chrome.storage.local.set({"leakedKeys": result.leakedKeys});
             chrome.action.setBadgeText({text: ''});
             document.getElementById("findingList").innerHTML = "";
         })

--- a/popup.js
+++ b/popup.js
@@ -57,14 +57,16 @@ for (i = 0; i < acc.length; i++) {
       panel.style.display = "block";
       var el = document.getElementById("denyList");
       chrome.storage.sync.get(["originDenyList"], function(result) {
-        el.value = result.originDenyList.join(",");
+        el.value = (result.originDenyList || []).join(",");
         el.focus();
       })
-      chrome.tabs.getSelected(null,function(tab) {
+      chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+        var tab = tabs[0];
 
         var origin = (new URL(tab.url)).origin;
         chrome.storage.sync.get(["leakedKeys"], function(result) {
-            var keys = result.leakedKeys[origin];
+            var leakedKeys = result.leakedKeys || {};
+            var keys = leakedKeys[origin];
             let keyInfo = "";
             let htmlList = "";
             if(!keys){keys = []}
@@ -87,8 +89,9 @@ for (i = 0; i < acc.length; i++) {
 var downloadCSV = function(){
     chrome.storage.sync.get(["leakedKeys"], function(result) {
         let csvRows = [];
-        for (let origin in result.leakedKeys){
-            var findings = result.leakedKeys[origin];
+        var leakedKeys = result.leakedKeys || {};
+        for (let origin in leakedKeys){
+            var findings = leakedKeys[origin];
             for (finding of findings){
                 csvRows.push([origin, finding["src"], finding["parentUrl"], finding["key"], finding["match"], finding["encoded"]])
             }
@@ -105,22 +108,25 @@ document.getElementById("downloadAllFindings").addEventListener("click", functio
 })
 document.getElementById("clearOriginFindings").addEventListener("click", function() {
     chrome.storage.sync.get(["leakedKeys"], function(result) {
-        chrome.tabs.getSelected(null,function(tab) {
+        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            var tab = tabs[0];
             var origin = (new URL(tab.url)).origin;
-            result.leakedKeys[origin] = {};
-            chrome.storage.sync.set({"leakedKeys": result.leakedKeys});
-            chrome.browserAction.setBadgeText({text: ''});
+            var leakedKeys = result.leakedKeys || {};
+            leakedKeys[origin] = [];
+            chrome.storage.sync.set({"leakedKeys": leakedKeys});
+            chrome.action.setBadgeText({text: ''});
             document.getElementById("findingList").innerHTML = "";
         })
     })
 })
 document.getElementById("clearAllFindings").addEventListener("click", function() {
     chrome.storage.sync.get(["leakedKeys"], function(result) {
-        chrome.tabs.getSelected(null,function(tab) {
+        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            var tab = tabs[0];
             var origin = (new URL(tab.url)).origin;
             result.leakedKeys = {};
             chrome.storage.sync.set({"leakedKeys": result.leakedKeys});
-            chrome.browserAction.setBadgeText({text: ''});
+            chrome.action.setBadgeText({text: ''});
             document.getElementById("findingList").innerHTML = "";
         })
     })


### PR DESCRIPTION
## Summary
Migrates the Chrome extension from Manifest V2 to Manifest V3 so it can be loaded in current Chrome versions.

The extension was failing to install because Chrome no longer supports the old manifest format. This updates the manifest, replaces deprecated extension APIs with Manifest V3 equivalents, and keeps the existing secret-finding logic unchanged. It also handles failed background fetches so blocked or unreachable script URLs do not create uncaught promise errors while scanning.

## Review guidance
- **Urgent** (needs same-day review): no
- **High complexity** (non-obvious logic, careful review): no
- **Estimated review time**: 15 min
- **Key files to focus on**: `manifest.json`, `background.js`, `popup.js`
- **Areas you're unsure about**: Manifest V3 service worker behavior across longer browsing sessions

## Testing
- [x] Loaded the extension as an unpacked extension in Chrome
- [x] Verified the Manifest V2 install error is resolved
- [x] Verified `background.js` passes syntax check
- [x] Verified `popup.js` passes syntax check
- [x] Verified `inject.js` passes syntax check
- [x] Verified failed fetches no longer surface as uncaught promise errors

## Deployment notes
No migrations or feature flags required. Reload the unpacked extension after updating. Rollback is reverting this PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> MV3 service worker migration and API/storage changes can affect background execution timing and persistence (notably `sync`→`local`) and may subtly change when/if scans and badge updates run.
> 
> **Overview**
> Updates the Chrome extension to **Manifest V3** by switching the background page to a `service_worker`, moving URL patterns into `host_permissions`, and adding the `notifications` permission.
> 
> Refactors `background.js` and `popup.js` to use MV3-compatible APIs (`chrome.action`, `chrome.runtime.*`, `tabs.query`), initializes defaults via `onInstalled`, and stores findings in `chrome.storage.local` (with safer null/undefined handling) while replacing blocking `alert()`s with `chrome.notifications`.
> 
> Adds a small `fetchText` helper to reuse fetch logic and suppress uncaught promise errors when remote resources can’t be fetched during scanning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01e598a26fbb88a9186084887cfc19cabf083d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->